### PR TITLE
Add securityMatcher to AdminSecurityConfiguration

### DIFF
--- a/spring-security-kotlin-dsl/src/main/kotlin/com/baeldung/security/kotlin/dsl/SpringSecurityKotlinApplication.kt
+++ b/spring-security-kotlin-dsl/src/main/kotlin/com/baeldung/security/kotlin/dsl/SpringSecurityKotlinApplication.kt
@@ -23,6 +23,7 @@ class SpringSecurityKotlinApplication
 class AdminSecurityConfiguration : WebSecurityConfigurerAdapter() {
     override fun configure(http: HttpSecurity?) {
         http {
+            securityMatcher("/greetings/**")
             authorizeRequests {
                 authorize("/greetings/**", hasAuthority("ROLE_ADMIN"))
             }


### PR DESCRIPTION
Without a custom `securityMatcher`, the `AdminSecurityConfiguration` will match all requests, meaning no request will reach `BasicSecurityConfiguration`.

Setting the `securityMatcher` to `"/greetings/**"` means requests that match `"/greetings/**"` will be processed by the `AdminSecurityConfiguration`, while the rest of the requests will be processed by the `BasicSecurityConfiguration`.
This is the behaviour that the tutorial describes.

The code should also be updated in the tutorial https://www.baeldung.com/kotlin/spring-security-dsl

