### PR TITLE
delete file before test case to enable running same test repeatedly.

### DIFF
--- a/core-kotlin-modules/core-kotlin-io/src/test/kotlin/com/baeldung/streamtofile/InputStreamToFileUnitTest.kt
+++ b/core-kotlin-modules/core-kotlin-io/src/test/kotlin/com/baeldung/streamtofile/InputStreamToFileUnitTest.kt
@@ -41,6 +41,7 @@ class InputStreamToFileUnitTest {
 
     @Test
     fun `Files$copy should copy any source to output stream`() {
+        Files.deleteIfExists(Paths.get("./copied"))
         val inputStream = ByteArrayInputStream(content.toByteArray())
 
         inputStream.use { input ->


### PR DESCRIPTION
Inside the directory `core-kotlin-modules/core-kotlin-io` when the project is build repeatedly with `mvn clean install` it gives below error. In order to resolve the error file has to be deleted before running the test case.

-------------------------------------------------------------------------------
Test set: com.baeldung.streamtofile.InputStreamToFileUnitTest
-------------------------------------------------------------------------------
Tests run: 4, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.116 s <<< FAILURE! - in com.baeldung.streamtofile.InputStreamToFileUnitTest
Files$copy should copy any source to output stream  Time elapsed: 0.007 s  <<< ERROR!
java.nio.file.FileAlreadyExistsException: ./copied
	at com.baeldung.streamtofile.InputStreamToFileUnitTest.Files$copy should copy any source to output stream(InputStreamToFileUnitTest.kt:48)

