### PR TITLE
KTLN-440: Demonstrate ordinal property and ordinal vs non-ordinal enums

### DIFF
--- a/core-kotlin-modules/core-kotlin-lang-oop/src/main/kotlin/com/baeldung/enums/PlayingCard.kt
+++ b/core-kotlin-modules/core-kotlin-lang-oop/src/main/kotlin/com/baeldung/enums/PlayingCard.kt
@@ -1,0 +1,27 @@
+package com.baeldung.enums
+
+enum class Suit {
+    HEARTS, DIAMONDS, CLUBS, SPADES
+}
+
+enum class Rank(val value: Int) : Comparable<Rank> {
+    ACE(1),
+    TWO(2),
+    THREE(3),
+    FOUR(4),
+    FIVE(5),
+    SIX(6),
+    SEVEN(7),
+    EIGHT(8),
+    NINE(9),
+    TEN(10),
+    JACK(11),
+    QUEEN(12),
+    KING(13);
+}
+
+enum class PlayingCard(val rank: Rank, val suit: Suit) {
+    KING_OF_SPADES(Rank.KING, Suit.SPADES),
+    QUEEN_OF_DIAMONDS(Rank.QUEEN, Suit.DIAMONDS);
+    // we can define more like this
+}

--- a/core-kotlin-modules/core-kotlin-lang-oop/src/main/kotlin/com/baeldung/enums/Weekday.kt
+++ b/core-kotlin-modules/core-kotlin-lang-oop/src/main/kotlin/com/baeldung/enums/Weekday.kt
@@ -1,0 +1,11 @@
+package com.baeldung.enums;
+
+enum class Weekday {
+    SUNDAY,
+    MONDAY,
+    TUESDAY,
+    WEDNESDAY,
+    THURSDAY,
+    FRIDAY,
+    SATURDAY,
+}

--- a/core-kotlin-modules/core-kotlin-lang-oop/src/test/kotlin/com/baeldung/enums/PlayingCardUnitTest.kt
+++ b/core-kotlin-modules/core-kotlin-lang-oop/src/test/kotlin/com/baeldung/enums/PlayingCardUnitTest.kt
@@ -1,0 +1,34 @@
+package com.baeldung.enums
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.util.Comparator
+
+class PlayingCardUnitTest {
+
+    @Test
+    fun givenPlayingCard_whenGetOrdinalValue_thenReturnZeroBasedIndex() {
+        Assertions.assertEquals(0, PlayingCard.KING_OF_SPADES.ordinal)
+        Assertions.assertEquals(1, PlayingCard.QUEEN_OF_DIAMONDS.ordinal)
+    }
+
+    @Test
+    fun givenPlayingCards_whenComparedUsingCompareTo_thenReturnWrongResult() {
+        Assertions.assertTrue(PlayingCard.KING_OF_SPADES.compareTo(PlayingCard.QUEEN_OF_DIAMONDS) < 0)
+    }
+
+    @Test
+    fun givenPlayingCards_whenSortedWithRankComparator_thenReturnCorrectOrder() {
+        val rankComparator = Comparator<Rank> { r1, r2 ->
+            r1.value - r2.value
+        }
+        val playingCardComparator = Comparator<PlayingCard> { pc1, pc2 ->
+            rankComparator.compare(pc1.rank, pc2.rank)
+        }
+        val playingCards = listOf(PlayingCard.KING_OF_SPADES, PlayingCard.QUEEN_OF_DIAMONDS)
+        val sortedPlayingCards = playingCards.sortedWith(playingCardComparator)
+
+        Assertions.assertEquals(PlayingCard.QUEEN_OF_DIAMONDS, sortedPlayingCards[0])
+        Assertions.assertEquals(PlayingCard.KING_OF_SPADES, sortedPlayingCards[1])
+    }
+}

--- a/core-kotlin-modules/core-kotlin-lang-oop/src/test/kotlin/com/baeldung/enums/WeekdayUnitTest.kt
+++ b/core-kotlin-modules/core-kotlin-lang-oop/src/test/kotlin/com/baeldung/enums/WeekdayUnitTest.kt
@@ -1,0 +1,54 @@
+package com.baeldung.enums;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class WeekdayUnitTest {
+
+    @Test
+    fun givenArrayValuesOfWeekend_whenMatchAgainstValuesMethod_thenFindExactMatch() {
+        val expectedWeekdayValues = arrayOf(
+            Weekday.SUNDAY,
+            Weekday.MONDAY,
+            Weekday.TUESDAY,
+            Weekday.WEDNESDAY,
+            Weekday.THURSDAY,
+            Weekday.FRIDAY,
+            Weekday.SATURDAY
+        )
+        val actualWeekdayValues = Weekday.values()
+        Assertions.assertArrayEquals(expectedWeekdayValues, actualWeekdayValues)
+    }
+
+    @Test
+    fun givenWeekday_whenInvokeCompareTo_thenReturnOrdinalValueDiff() {
+        Assertions.assertEquals(1, Weekday.MONDAY.compareTo(Weekday.SUNDAY))
+        Assertions.assertEquals(1, Weekday.TUESDAY.compareTo(Weekday.MONDAY))
+        Assertions.assertEquals(1, Weekday.WEDNESDAY.compareTo(Weekday.TUESDAY))
+        Assertions.assertEquals(1, Weekday.THURSDAY.compareTo(Weekday.WEDNESDAY))
+        Assertions.assertEquals(1, Weekday.FRIDAY.compareTo(Weekday.THURSDAY))
+        Assertions.assertEquals(1, Weekday.SATURDAY.compareTo(Weekday.FRIDAY))
+    }
+
+    @Test
+    fun givenWeekday_whenGetOrdinalValue_thenReturnZeroBasedIndex() {
+        Assertions.assertEquals(0, Weekday.SUNDAY.ordinal)
+        Assertions.assertEquals(1, Weekday.MONDAY.ordinal)
+        Assertions.assertEquals(2, Weekday.TUESDAY.ordinal)
+        Assertions.assertEquals(3, Weekday.WEDNESDAY.ordinal)
+        Assertions.assertEquals(4, Weekday.THURSDAY.ordinal)
+        Assertions.assertEquals(5, Weekday.FRIDAY.ordinal)
+        Assertions.assertEquals(6, Weekday.SATURDAY.ordinal)
+    }
+
+    @Test
+    fun givenOrdinalValue_whenGetWeekdayFromValues_thenReturnWeekdayEnum() {
+        Assertions.assertEquals(Weekday.SUNDAY, Weekday.values()[0])
+        Assertions.assertEquals(Weekday.MONDAY, Weekday.values()[1])
+        Assertions.assertEquals(Weekday.TUESDAY, Weekday.values()[2])
+        Assertions.assertEquals(Weekday.WEDNESDAY, Weekday.values()[3])
+        Assertions.assertEquals(Weekday.THURSDAY, Weekday.values()[4])
+        Assertions.assertEquals(Weekday.FRIDAY, Weekday.values()[5])
+        Assertions.assertEquals(Weekday.SATURDAY, Weekday.values()[6])
+    }
+}


### PR DESCRIPTION
## Summary
- Demonstrate ordinal property of enums
- Differentiate ordinal vs non-ordinal enums.

# Jira
[KTLN-440](https://jira.baeldung.com/browse/KTLN-440)