### PR TITLE
KTLN-519 - quick fix - removing unused argument

### DIFF
--- a/core-kotlin-modules/core-kotlin-advanced-2/src/test/kotlin/com/baeldung/callback/CallbackFunctionTest.kt
+++ b/core-kotlin-modules/core-kotlin-advanced-2/src/test/kotlin/com/baeldung/callback/CallbackFunctionTest.kt
@@ -91,7 +91,7 @@ class CallbackFunctionTest {
             return false
         }
 
-        fun openPDF(userId: Int, bookId: Int){
+        fun openPDF(bookId: Int){
             downloadBook { id ->
                 saveBook(bookId){bookId ->
                     openBook(bookId)


### PR DESCRIPTION
Based on a comment:

```
The code has issues:

“val listofUsers = emptyList<User>()” should be “var listofUsers = emptyList<User>()”, else you can’t reassign listofUsers later on
the callback hell code is confusing even without those callbacks, e.g. what does openBook() do, and why is the userId argument of openPDF(userId: Int, bookId: Int) not used?
```